### PR TITLE
#include "" instead #include <>

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -1,7 +1,7 @@
 #include-once
 #include <WinAPIProc.au3>
-#include <JSON.au3> ; https://www.autoitscript.com/forum/topic/148114-a-non-strict-json-udf-jsmn
-#include <WinHttp.au3> ; https://www.autoitscript.com/forum/topic/84133-winhttp-functions/
+#include "JSON.au3" ; https://www.autoitscript.com/forum/topic/148114-a-non-strict-json-udf-jsmn
+#include "WinHttp.au3" ; https://www.autoitscript.com/forum/topic/84133-winhttp-functions/
 
 #Region Copyright
 #cs


### PR DESCRIPTION
This two following include files
```
#include <JSON.au3>
#include <WinHttp.au3>
```

are not Standard AutoIt UDF so should be used "" instead <>
```
#include "JSON.au3"
#include "WinHttp.au3"
```

according to helpfile
https://www.autoitscript.com/autoit3/files/beta/autoit/docs/keywords/include.htm


```
If "..." is used, the filename is taken to be relative to the current script.
If <...> is used the filename is taken to be relative to include library directory (usually C:\Program Files\AutoIt3\Include). The include library contains many pre-written user-functions for you to use!
```
