### PR TITLE
_WD_ElementActionEx - "clickandhold" description

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -1645,6 +1645,7 @@ EndFunc
 ;                                           | hover
 ;                                           | doubleclick
 ;                                           | rightclick
+;                                           | clickandhold
 ;                                           | hide
 ;                                           | show
 ;                                           | childcount


### PR DESCRIPTION
In  _WD_ElementActionEx() header in Parameters Description there was lack of "clickandhold"