### PR TITLE
_WD_Screenshot - better @error handling

### DIFF
--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -771,6 +771,7 @@ EndFunc   ;==>_WD_LoadWait
 ; Return values .: Success - Output of specified type (PNG format).
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_NoMatch
+;                  - $_WD_ERROR_GeneralError
 ;                  - $_WD_ERROR_Exception
 ;                  - $_WD_ERROR_InvalidDataType
 ;                  - $_WD_ERROR_InvalidExpression

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -795,7 +795,7 @@ Func _WD_Screenshot($sSession, $sElement = Default, $iOutputType = Default)
 	EndIf
 	$iErr = @error
 
-	If $iErr = $_WD_ERROR_Success  Then
+	If $iErr = $_WD_ERROR_Success Then
 		If $iOutputType < 3 Then $dBinary = __WD_Base64Decode($sResponse)
 		If @error Then ; Recheck after __WD_Base64Decode() usage
 			$iErr = $_WD_ERROR_GeneralError

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -781,8 +781,7 @@ EndFunc   ;==>_WD_LoadWait
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func _WD_Screenshot($sSession, $sElement = Default,
-	OutputType = Default)
+Func _WD_Screenshot($sSession, $sElement = Default, $iOutputType = Default)
 	Local Const $sFuncName = "_WD_Screenshot"
 	Local $sResponse, $sResult = "", $iErr, $dBinary
 

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -796,10 +796,11 @@ Func _WD_Screenshot($sSession, $sElement = Default, $iOutputType = Default)
 	$iErr = @error
 
 	If $iErr = $_WD_ERROR_Success Then
-		If $iOutputType < 3 Then $dBinary = __WD_Base64Decode($sResponse)
-		If @error Then ; Recheck after __WD_Base64Decode() usage
-			$iErr = $_WD_ERROR_GeneralError
-		Else
+		If $iOutputType < 3 Then
+			$dBinary = __WD_Base64Decode($sResponse)
+			If @error Then $iErr = $_WD_ERROR_GeneralError
+		EndIf
+		If $iErr = $_WD_ERROR_Success Then ; Recheck after __WD_Base64Decode() usage
 			Switch $iOutputType
 				Case 1 ; String
 					$vResult = BinaryToString($dBinary)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -783,7 +783,7 @@ EndFunc   ;==>_WD_LoadWait
 ; ===============================================================================================================================
 Func _WD_Screenshot($sSession, $sElement = Default, $nOutputType = Default)
 	Local Const $sFuncName = "_WD_Screenshot"
-	Local $sResponse, $sResult = "", $iErr
+	Local $sResponse, $sResult = "", $iErr, $dBinary
 
 	If $sElement = Default Then $sElement = ""
 	If $nOutputType = Default Then $nOutputType = 1
@@ -795,13 +795,13 @@ Func _WD_Screenshot($sSession, $sElement = Default, $nOutputType = Default)
 	EndIf
 	$iErr = @error
 
+	If $iErr = $_WD_ERROR_Success And $nOutputType < 3 Then
+		$dBinary = __WD_Base64Decode($sResponse)
+		If @error Then $iErr = $_WD_ERROR_GeneralError
+	EndIf
+
 	If $iErr = $_WD_ERROR_Success Then
-		Local $dBinary
 		Switch $nOutputType
-			Case 1, 2 ; String or Binary - pre processing
-				$dBinary = __WD_Base64Decode($sResponse)
-				If Not @error Then ContinueCase
-				$iErr = $_WD_ERROR_GeneralError
 			Case 1 ; String
 				$sResult = BinaryToString($dBinary)
 			Case 2 ; Binary

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -772,6 +772,7 @@ EndFunc   ;==>_WD_LoadWait
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_NoMatch
 ;                  - $_WD_ERROR_Exception
+;                  - $_WD_ERROR_GeneralError
 ;                  - $_WD_ERROR_InvalidDataType
 ;                  - $_WD_ERROR_InvalidExpression
 ; Author ........: Danp2

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -798,7 +798,7 @@ Func _WD_Screenshot($sSession, $sElement = Default, $nOutputType = Default)
 	If $iErr = $_WD_ERROR_Success Then
 		Local $dBinary
 		Switch $nOutputType
-			Case 1, 2 ; String or Binary
+			Case 1, 2 ; String or Binary - pre processing
 				$dBinary = __WD_Base64Decode($sResponse)
 				If Not @error Then ContinueCase
 				$iErr = $_WD_ERROR_GeneralError

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -783,7 +783,7 @@ EndFunc   ;==>_WD_LoadWait
 ; ===============================================================================================================================
 Func _WD_Screenshot($sSession, $sElement = Default, $iOutputType = Default)
 	Local Const $sFuncName = "_WD_Screenshot"
-	Local $sResponse, $sResult = "", $iErr, $dBinary
+	Local $sResponse, $vResult = "", $iErr, $dBinary
 
 	If $sElement = Default Then $sElement = ""
 	If $iOutputType = Default Then $iOutputType = 1
@@ -796,24 +796,22 @@ Func _WD_Screenshot($sSession, $sElement = Default, $iOutputType = Default)
 	$iErr = @error
 
 	If $iErr = $_WD_ERROR_Success  Then
-		If $iOutputType < 3 Then
-			$dBinary = __WD_Base64Decode($sResponse)
-			If @error Then $iErr = $_WD_ERROR_GeneralError
-		EndIf
-
-		If $iErr = $_WD_ERROR_Success Then ; Recheck after __WD_Base64Decode() usage
+		If $iOutputType < 3 Then $dBinary = __WD_Base64Decode($sResponse)
+		If @error Then ; Recheck after __WD_Base64Decode() usage
+			$iErr = $_WD_ERROR_GeneralError
+		Else
 			Switch $iOutputType
 				Case 1 ; String
-					$sResult = BinaryToString($dBinary)
+					$vResult = BinaryToString($dBinary)
 				Case 2 ; Binary
-					$sResult = $dBinary
+					$vResult = $dBinary
 				Case 3 ; Base64
-					$sResult = $sResponse
+					$vResult = $sResponse
 			EndSwitch
 		EndIf
 	EndIf
 
-	Return SetError(__WD_Error($sFuncName, $iErr), 0, $sResult)
+	Return SetError(__WD_Error($sFuncName, $iErr), 0, $vResult)
 EndFunc   ;==>_WD_Screenshot
 
 ; #FUNCTION# ====================================================================================================================

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -761,17 +761,16 @@ EndFunc   ;==>_WD_LoadWait
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _WD_Screenshot
 ; Description ...: Takes a screenshot of the Window or Element.
-; Syntax ........: _WD_Screenshot($sSession[, $sElement = Default[, $nOutputType = Default]])
+; Syntax ........: _WD_Screenshot($sSession[, $sElement = Default[, $iOutputType = Default]])
 ; Parameters ....: $sSession    - Session ID from _WD_CreateSession
 ;                  $sElement    - [optional] Element ID from _WD_FindElement
-;                  $nOutputType - [optional] One of the following output types:
+;                  $iOutputType - [optional] One of the following output types:
 ;                  |1 - String (Default)
 ;                  |2 - Binary
 ;                  |3 - Base64
 ; Return values .: Success - Output of specified type (PNG format).
 ;                  Failure - "" (empty string) and sets @error to one of the following values:
 ;                  - $_WD_ERROR_NoMatch
-;                  - $_WD_ERROR_GeneralError
 ;                  - $_WD_ERROR_Exception
 ;                  - $_WD_ERROR_InvalidDataType
 ;                  - $_WD_ERROR_InvalidExpression
@@ -782,12 +781,13 @@ EndFunc   ;==>_WD_LoadWait
 ; Link ..........:
 ; Example .......: No
 ; ===============================================================================================================================
-Func _WD_Screenshot($sSession, $sElement = Default, $nOutputType = Default)
+Func _WD_Screenshot($sSession, $sElement = Default,
+	OutputType = Default)
 	Local Const $sFuncName = "_WD_Screenshot"
 	Local $sResponse, $sResult = "", $iErr, $dBinary
 
 	If $sElement = Default Then $sElement = ""
-	If $nOutputType = Default Then $nOutputType = 1
+	If $iOutputType = Default Then $iOutputType = 1
 
 	If $sElement = '' Then
 		$sResponse = _WD_Window($sSession, 'Screenshot')
@@ -796,13 +796,13 @@ Func _WD_Screenshot($sSession, $sElement = Default, $nOutputType = Default)
 	EndIf
 	$iErr = @error
 
-	If $iErr = $_WD_ERROR_Success And $nOutputType < 3 Then
+	If $iErr = $_WD_ERROR_Success And $iOutputType < 3 Then
 		$dBinary = __WD_Base64Decode($sResponse)
 		If @error Then $iErr = $_WD_ERROR_GeneralError
 	EndIf
 
 	If $iErr = $_WD_ERROR_Success Then
-		Switch $nOutputType
+		Switch $iOutputType
 			Case 1 ; String
 				$sResult = BinaryToString($dBinary)
 			Case 2 ; Binary

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -801,7 +801,7 @@ Func _WD_Screenshot($sSession, $sElement = Default,
 		If @error Then $iErr = $_WD_ERROR_GeneralError
 	EndIf
 
-	If $iErr = $_WD_ERROR_Success Then
+	If $iErr = $_WD_ERROR_Success Then ; it need to be rechecked after __WD_Base64Decode() usage
 		Switch $iOutputType
 			Case 1 ; String
 				$sResult = BinaryToString($dBinary)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -775,7 +775,7 @@ EndFunc   ;==>_WD_LoadWait
 ;                  - $_WD_ERROR_InvalidDataType
 ;                  - $_WD_ERROR_InvalidExpression
 ; Author ........: Danp2
-; Modified ......:
+; Modified ......: mLipok
 ; Remarks .......:
 ; Related .......: _WD_Window, _WD_ElementAction
 ; Link ..........:
@@ -783,30 +783,32 @@ EndFunc   ;==>_WD_LoadWait
 ; ===============================================================================================================================
 Func _WD_Screenshot($sSession, $sElement = Default, $nOutputType = Default)
 	Local Const $sFuncName = "_WD_Screenshot"
-	Local $sResponse, $sResult, $iErr
+	Local $sResponse, $sResult = "", $iErr
 
 	If $sElement = Default Then $sElement = ""
 	If $nOutputType = Default Then $nOutputType = 1
 
 	If $sElement = '' Then
 		$sResponse = _WD_Window($sSession, 'Screenshot')
-		$iErr = @error
 	Else
 		$sResponse = _WD_ElementAction($sSession, $sElement, 'Screenshot')
-		$iErr = @error
 	EndIf
+	$iErr = @error
 
 	If $iErr = $_WD_ERROR_Success Then
+		Local $dBinary
 		Switch $nOutputType
+			Case 1, 2 ; String or Binary
+				$dBinary = __WD_Base64Decode($sResponse)
+				$iErr = @error
+				If Not @error Then ContinueCase
 			Case 1 ; String
-				$sResult = BinaryToString(__WD_Base64Decode($sResponse))
+				$sResult = BinaryToString($dBinary)
 			Case 2 ; Binary
-				$sResult = __WD_Base64Decode($sResponse)
+				$sResult = $dBinary
 			Case 3 ; Base64
 				$sResult = $sResponse
 		EndSwitch
-	Else
-		$sResult = ''
 	EndIf
 
 	Return SetError(__WD_Error($sFuncName, $iErr), 0, $sResult)

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -800,8 +800,8 @@ Func _WD_Screenshot($sSession, $sElement = Default, $nOutputType = Default)
 		Switch $nOutputType
 			Case 1, 2 ; String or Binary
 				$dBinary = __WD_Base64Decode($sResponse)
-				$iErr = @error
 				If Not @error Then ContinueCase
+				$iErr = $_WD_ERROR_GeneralError
 			Case 1 ; String
 				$sResult = BinaryToString($dBinary)
 			Case 2 ; Binary

--- a/wd_helper.au3
+++ b/wd_helper.au3
@@ -795,20 +795,22 @@ Func _WD_Screenshot($sSession, $sElement = Default, $iOutputType = Default)
 	EndIf
 	$iErr = @error
 
-	If $iErr = $_WD_ERROR_Success And $iOutputType < 3 Then
-		$dBinary = __WD_Base64Decode($sResponse)
-		If @error Then $iErr = $_WD_ERROR_GeneralError
-	EndIf
+	If $iErr = $_WD_ERROR_Success  Then
+		If $iOutputType < 3 Then
+			$dBinary = __WD_Base64Decode($sResponse)
+			If @error Then $iErr = $_WD_ERROR_GeneralError
+		EndIf
 
-	If $iErr = $_WD_ERROR_Success Then ; it need to be rechecked after __WD_Base64Decode() usage
-		Switch $iOutputType
-			Case 1 ; String
-				$sResult = BinaryToString($dBinary)
-			Case 2 ; Binary
-				$sResult = $dBinary
-			Case 3 ; Base64
-				$sResult = $sResponse
-		EndSwitch
+		If $iErr = $_WD_ERROR_Success Then ; Recheck after __WD_Base64Decode() usage
+			Switch $iOutputType
+				Case 1 ; String
+					$sResult = BinaryToString($dBinary)
+				Case 2 ; Binary
+					$sResult = $dBinary
+				Case 3 ; Base64
+					$sResult = $sResponse
+			EndSwitch
+		EndIf
 	EndIf
 
 	Return SetError(__WD_Error($sFuncName, $iErr), 0, $sResult)


### PR DESCRIPTION
Please also take a look on 
`Func __WD_Base64Decode($input_string)`
as the description:
`; Return values .: Decoded string`

doesn't conatin information about Success/Failure/@error
