### PR TITLE
wd_demo.au3 _RunDemo_Update() should back to main loop on error

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -240,7 +240,6 @@ Func _RunDemo_Update($idUpdate, $sBrowserName)
 	If $sUpdate = 'Report only' Then $bForce = Null
 
 	Local $bUpdateResult = _WD_UpdateDriver($sBrowserName, @ScriptDir, $bFlag64, $bForce)
-	ConsoleWrite('> UpdateResult = ' & $bUpdateResult & @CRLF)
 	Local $iErr = @error, $iExt = @extended
 	ConsoleWrite('> UpdateResult = ' & $bUpdateResult & @CRLF)
 	Return SetError($iErr, $iExt, $bUpdateResult)


### PR DESCRIPTION
## Pull request

### Proposed changes

_RunDemo_Update() should back to main loop on error
Currently I notice some issue with updating chromedriver.exe and testing with wd_demo.au3 the scirpts goes over the issue (even with forced update) instead ends on non updated driver

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

on dirver update errors the program still is trying to go ahead

### What is the new behavior?

on dirver update errors the program back to main loop

### Influences and relationship to other functionality

none

### Additional context

none

### System under test
Wersja 121.0.6167.185 (Oficjalna wersja) (64-bitowa)