### PR TITLE
wd_demo.au3 - output in @compiled mode

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -114,6 +114,7 @@ Func _WD_Demo()
 	GUICtrlCreateLabel("ConsoleOut", 15, $iPos + 2)
 	Local $idOutput = GUICtrlCreateCombo("ConsoleWrite", 75, $iPos, 100, 20, $CBS_DROPDOWNLIST)
 	GUICtrlSetData($idOutput, "WD_Console.log|_DebugOut|Null", "ConsoleWrite")
+	If @Compiled Then GUICtrlSetData($idOutput, "_DebugOut") ; set the default value for the compiled version to be able to see the logs
 	#EndRegion - Output
 
 	#Region - demos


### PR DESCRIPTION
setting the default value for the compiled version to be able to see the logs

## Pull request

### Proposed changes

in compiled version you should see logs thus default output to console is not good option

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [X] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [X] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

output is set to `ConsoleWrite`

### What is the new behavior?

output is set to `_DebugOut`

### Influences and relationship to other functionality

none

### Additional context

none

### System under test

not related