### PR TITLE
_WD_CapabilitiesDefine() - refactoring + suplement for logs

### DIFF
--- a/wd_capabilities.au3
+++ b/wd_capabilities.au3
@@ -368,7 +368,7 @@ Func _WD_CapabilitiesDefine(ByRef $sCapabilityType, $sCapabilityName)
 		Return SetError(__WD_Error($sFuncName, $_WD_ERROR_AlreadyDefined, $sMessage))
 	EndIf
 
-	$sCapabilityType = StringTrimRight($sCapabilityType, 3) & '|' & $sCapabilityName & ')\Z' ; adding new
+	$sCapabilityType = StringTrimRight($sCapabilityType, 3) & '|' & $sCapabilityName & ')\Z'
 
 	$sMessage = 'Capability: "' & $sCapabilityName & '"  Suplemented into: ' & $sCapabilityKeyName & ' = ' & $sCapabilityType
 	Return SetError(__WD_Error($sFuncName, $_WD_ERROR_Success, $sMessage))


### PR DESCRIPTION
## Pull request

### Proposed changes

Refactoring - moving `Unsupported capability type` to top as it is first parameter and should be checked in first place
Logs - `$sCapabilityKeyName` shows the name in console log

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

in logs **you not see then name of** $_WD_KEYS__*** which was used to define new Capability
using:
```autoit
_WD_CapabilitiesDefine($_WD_KEYS__SPECIFICVENDOR_PRIMITIVE, 'useAutomationExtension')
```
you will see in console
```
_WD_CapabilitiesDefine ==> Success [0] : Capability: "useAutomationExtension"  Suplemented into: \A(binary|debuggerAddress|detach|minidumpPath|w3c|ie.edgepath|ie.edgechromium|ignoreProtectedModeSettings|initialBrowserUrl|useAutomationExtension)\Z
```


### What is the new behavior?

in logs **you see then name of** $_WD_KEYS__*** which was used to define new Capability
```autoit
_WD_CapabilitiesDefine($_WD_KEYS__SPECIFICVENDOR_PRIMITIVE, 'useAutomationExtension')
```
you will see in console
```
_WD_CapabilitiesDefine ==> Success [0] : Capability: "useAutomationExtension"  Suplemented into: SPECIFICVENDOR_PRIMITIVE = \A(binary|debuggerAddress|detach|minidumpPath|w3c|ie.edgepath|ie.edgechromium|ignoreProtectedModeSettings|initialBrowserUrl|useAutomationExtension)\Z
```

### Influences and relationship to other functionality

none

### Additional context

the concept of change was created as a result of the analysis of the following problem
https://github.com/Danp2/au3WebDriver/issues/531


### System under test

not related