### PR TITLE
Fix Edge webdriver URLS

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -223,9 +223,9 @@ Global Const $_WD_SupportedBrowsers[][$_WD_BROWSER__COUNTER] = _
 				"msedgedriver.exe", _
 				True,  _
 				"ms:edgeOptions", _
-				"'https://msedgedriver.azureedge.net/LATEST_RELEASE_' & StringLeft($sBrowserVersion, StringInStr($sBrowserVersion, '.') - 1) & '_WINDOWS'", _
+				"'https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/LATEST_RELEASE_' & StringLeft($sBrowserVersion, StringInStr($sBrowserVersion, '.') - 1) & '_WINDOWS'", _
 				"", _
-				'"https://msedgedriver.azureedge.net/" & $sDriverLatest & "/edgedriver_" & (($bFlag64) ? "win64.zip" : "win32.zip")' _
+				'"https://msedgedriver.microsoft.com/" & $sDriverLatest & "/edgedriver_" & (($bFlag64) ? "win64.zip" : "win32.zip")' _
 			], _
 			[ _
 				"opera", _


### PR DESCRIPTION
## Pull request

### Proposed changes

The previous URLs for getting latest Edge webdriver are no longer valid. DNS doesn't resolve. Switched to currently working URLs.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [ ] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

Edge webdriver will not download or update.

### What is the new behavior?

Edge webdriver will now download and update.

### Influences and relationship to other functionality

None.

### Additional context

None.

### System under test

Please complete the following information.

- OS: Windows 11
- OS Arch.: X64
- Browser: Edge
- Browser version: 138.0.3351.95

