### PR TITLE
Update wd_demo.au3 - IsAdmin()

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1251,6 +1251,7 @@ Func SetupChrome($bHeadless)
 	_WD_CapabilitiesAdd('w3c', True)
 	_WD_CapabilitiesAdd('excludeSwitches', 'enable-automation')
 	If $bHeadless Then _WD_CapabilitiesAdd('args', '--headless')
+	If IsAdmin() Then _WD_CapabilitiesAdd('args', '--do-not-de-elevate')
 	_WD_CapabilitiesDump(@ScriptLineNumber) ; dump current Capabilities setting to console - only for testing in this demo
 	Local $sCapabilities = _WD_CapabilitiesGet()
 	Return $sCapabilities
@@ -1269,6 +1270,8 @@ Func SetupEdge($bHeadless)
 	_WD_CapabilitiesAdd('alwaysMatch', 'msedge')
 	_WD_CapabilitiesAdd('excludeSwitches', 'enable-automation')
 	If $bHeadless Then _WD_CapabilitiesAdd('args', '--headless')
+	If IsAdmin() Then _WD_CapabilitiesAdd('args', '--do-not-de-elevate')
+
 	_WD_CapabilitiesDump(@ScriptLineNumber) ; dump current Capabilities setting to console - only for testing in this demo
 	Local $sCapabilities = _WD_CapabilitiesGet()
 	Return $sCapabilities
@@ -1298,6 +1301,7 @@ Func SetupOpera($bHeadless)
 	EndIf
 
 	If $bHeadless Then _WD_CapabilitiesAdd('args', '--headless')
+	If IsAdmin() Then _WD_CapabilitiesAdd('args', '--do-not-de-elevate')
 	_WD_CapabilitiesDump(@ScriptLineNumber) ; dump current Capabilities setting to console - only for testing in this demo
 	Local $sCapabilities = _WD_CapabilitiesGet()
 	Return $sCapabilities


### PR DESCRIPTION
## Pull request

### Proposed changes

I recently had problems with projects using WebDriver with elevated admin rights.
I tested the problem using wd_demo.au3, and everything worked.

It was difficult to find the cause.
Therefore, I believe wd_demo.au3 should be prepared to work in elevated mode as well.


### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

chromium based browser wont start when script is elevated to admin rights

### What is the new behavior?

chromium based browser start properly when script is elevated to admin rights

### Influences and relationship to other functionality

none

### Additional context

https://github.com/Danp2/au3WebDriver/issues/532
https://www.autoitscript.com/forum/topic/210071-webdriver-and-admin-rights

### System under test
all chromium based web browser
