### PR TITLE
Update wd_demo.au3 - Au3Stripper to support @ScriptLineNumber in compiled mode

### DIFF
--- a/wd_demo.au3
+++ b/wd_demo.au3
@@ -1,3 +1,8 @@
+#Region - using Au3Stripper to support @ScriptLineNumber in compiled mode
+#AutoIt3Wrapper_Run_Au3Stripper=Y
+#Au3Stripper_Parameters=/MO /RSLN
+#EndRegion - using Au3Stripper to support @ScriptLineNumber in compiled mode
+
 #Region - include files
 ; standard UDF's
 #include <ButtonConstants.au3>


### PR DESCRIPTION
## Pull request

### Proposed changes

Recently I proposed the already merged : https://github.com/Danp2/au3WebDriver/pull/534
Here I propose to continue this topic.

In compiled mode all information in the output should provide according information, all together with script line numbers.

### Checklist

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

In compiled mode in the output the information are not complementary, thus my https://github.com/Danp2/au3WebDriver/pull/540

But script line numbers would be `-1` in compiled mode. 

### What is the new behavior?

In compiled mode, the proper line numbers are included in the results outputed to the selected output.

### Influences and relationship to other functionality

none

### Additional context

https://github.com/Danp2/au3WebDriver/pull/534

https://github.com/Danp2/au3WebDriver/pull/540

### System under test

not releated