### PR TITLE
Update $_WD_BROWSER_LatestReleaseURL value for msedgedriver.

### DIFF
--- a/wd_core.au3
+++ b/wd_core.au3
@@ -223,7 +223,7 @@ Global Const $_WD_SupportedBrowsers[][$_WD_BROWSER__COUNTER] = _
 				"msedgedriver.exe", _
 				True,  _
 				"ms:edgeOptions", _
-				"'https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/LATEST_RELEASE_' & StringLeft($sBrowserVersion, StringInStr($sBrowserVersion, '.') - 1) & '_WINDOWS'", _
+				"'https://msedgedriver.microsoft.com/LATEST_RELEASE_' & StringLeft($sBrowserVersion, StringInStr($sBrowserVersion, '.') - 1) & '_WINDOWS'", _
 				"", _
 				'"https://msedgedriver.microsoft.com/" & $sDriverLatest & "/edgedriver_" & (($bFlag64) ? "win64.zip" : "win32.zip")' _
 			], _


### PR DESCRIPTION
## Pull request

### Proposed changes

_WD_UpdateDriver fails to update msedgedriver to the latest version. This is due to Microsoft changing the URL that has been used previously for determining this. The needed change is to update the Latest Release URL for msedgedriver to use the new URL.

### Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We are here to help!<br>
This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read and noticed the [CODE OF CONDUCT](https://github.com/Danp2/au3WebDriver/blob/master/docs/CODE_OF_CONDUCT.md) document
- [x] I have read and noticed the [CONTRIBUTING](https://github.com/Danp2/au3WebDriver/blob/master/docs/CONTRIBUTING.md) document
- [x] I have added necessary documentation or screenshots (if appropriate)

### Types of changes

Please check `x` the type of change your PR introduces:

- [x] Bugfix (change which fixes an issue)
- [ ] Feature (change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (functional, structural)
- [ ] Documentation content changes
- [ ] Other (please describe)

### What is the current behavior?

_WD_UpdateDriver fails to determine a latest release for msedgedriver and as a result the latest version is not downloaded. This prevents the ability to interact with the current version of Edge browser installed.

### What is the new behavior?

_WD_UpdateDriver succeeds in determining the latest release for msedgedriver and downloads it. Ability to interact with current version of Edge browser is restored.

### Influences and relationship to other functionality

None.

### Additional context

None.

### System under test

Please complete the following information.

- OS: Windows 11 25H2
- OS Arch.: X64
- Browser: Edge
- Browser version: 147.0.3912.72

